### PR TITLE
Fixed locality names in IN

### DIFF
--- a/data/112/583/864/3/1125838643.geojson
+++ b/data/112/583/864/3/1125838643.geojson
@@ -25,6 +25,12 @@
     "name:ceb_x_preferred":[
         "Amba"
     ],
+    "name:eng_x_preferred":[
+        "Ambad"
+    ],
+    "name:eng_x_variant":[
+        "Amba"
+    ],
     "name:fra_x_preferred":[
         "Amba"
     ],
@@ -91,8 +97,8 @@
         }
     ],
     "wof:id":1125838643,
-    "wof:lastmodified":1566705421,
-    "wof:name":"Amba",
+    "wof:lastmodified":1568135765,
+    "wof:name":"Ambad",
     "wof:parent_id":890501997,
     "wof:placetype":"locality",
     "wof:population":29846,

--- a/data/122/582/391/5/1225823915.geojson
+++ b/data/122/582/391/5/1225823915.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sanghan"
+    ],
+    "name:eng_x_variant":[
+        "Sangan"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":1225823915,
-    "wof:lastmodified":1566713541,
-    "wof:name":"Sangan",
+    "wof:lastmodified":1568135769,
+    "wof:name":"Sanghan",
     "wof:parent_id":890502835,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",

--- a/data/129/305/721/1/1293057211.geojson
+++ b/data/129/305/721/1/1293057211.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Raunta"
+    ],
+    "name:eng_x_variant":[
+        "Raonta"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":1293057211,
-    "wof:lastmodified":1566691127,
-    "wof:name":"Raonta",
+    "wof:lastmodified":1568135773,
+    "wof:name":"Raunta",
     "wof:parent_id":890506131,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700

- Updates three locality records to include eng preferred and variant names
- Updates the `wof:name` to the correct value

No PIP work required, can merge once approved.