### PR TITLE
Locality name updates

### DIFF
--- a/data/132/702/413/5/1327024135.geojson
+++ b/data/132/702/413/5/1327024135.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Timbachudi"
+    ],
+    "name:eng_x_variant":[
+        "Tembachuri"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":1327024135,
-    "wof:lastmodified":1566683459,
-    "wof:name":"Tembachuri",
+    "wof:lastmodified":1573512148,
+    "wof:name":"Timbachudi",
     "wof:parent_id":890507093,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",

--- a/data/134/375/117/7/1343751177.geojson
+++ b/data/134/375/117/7/1343751177.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:bul_x_variant":[
+        "\u041f\u0430\u0440\u043e\u0434\u0438"
+    ],
+    "name:deu_x_variant":[
+        "Parodi"
+    ],
     "name:eng_x_preferred":[
         "Paravadi"
     ],
@@ -39,11 +45,23 @@
     "name:fra_x_preferred":[
         "Paravadi"
     ],
+    "name:fra_x_variant":[
+        "Parodi"
+    ],
     "name:ita_x_preferred":[
         "Paravadi"
     ],
+    "name:ita_x_variant":[
+        "Parodi"
+    ],
+    "name:rus_x_variant":[
+        "\u041f\u0430\u0440\u043e\u0434\u0438"
+    ],
     "name:spa_x_preferred":[
         "Paravadi"
+    ],
+    "name:spa_x_variant":[
+        "Parodi"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -68,7 +86,7 @@
         }
     ],
     "wof:id":1343751177,
-    "wof:lastmodified":1573513346,
+    "wof:lastmodified":1573513977,
     "wof:name":"Paravadi",
     "wof:parent_id":890509009,
     "wof:placetype":"locality",

--- a/data/134/375/117/7/1343751177.geojson
+++ b/data/134/375/117/7/1343751177.geojson
@@ -30,23 +30,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
-    "name:bul_x_preferred":[
-        "\u041f\u0430\u0440\u043e\u0434\u0438"
+    "name:eng_x_preferred":[
+        "Paravadi"
     ],
-    "name:deu_x_preferred":[
+    "name:eng_x_variant":[
         "Parodi"
     ],
     "name:fra_x_preferred":[
-        "Parodi"
+        "Paravadi"
     ],
     "name:ita_x_preferred":[
-        "Parodi"
-    ],
-    "name:rus_x_preferred":[
-        "\u041f\u0430\u0440\u043e\u0434\u0438"
+        "Paravadi"
     ],
     "name:spa_x_preferred":[
-        "Parodi"
+        "Paravadi"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -71,8 +68,8 @@
         }
     ],
     "wof:id":1343751177,
-    "wof:lastmodified":1566688681,
-    "wof:name":"Parodi",
+    "wof:lastmodified":1573513346,
+    "wof:name":"Paravadi",
     "wof:parent_id":890509009,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",

--- a/data/890/509/893/890509893.geojson
+++ b/data/890/509/893/890509893.geojson
@@ -21,52 +21,46 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "name:cat_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:ceb_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:ces_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:deu_x_preferred":[
-        "Bani"
+        "Basni"
     ],
-    "name:fas_x_preferred":[
-        "\u0628\u0627\u0646\u06cc"
+    "name:eng_x_preferred":[
+        "Basni"
+    ],
+    "name:eng_x_variant":[
+        "Bani"
     ],
     "name:fra_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:ita_x_preferred":[
-        "Bani"
-    ],
-    "name:kat_x_preferred":[
-        "\u10d1\u10d0\u10dc\u10d8"
+        "Basni"
     ],
     "name:nld_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:por_x_preferred":[
-        "Bani"
-    ],
-    "name:rus_x_preferred":[
-        "\u0411\u0430\u0441\u043d\u0438"
-    ],
-    "name:rus_x_variant":[
-        "\u0411\u0430\u043d\u0438"
+        "Basni"
     ],
     "name:spa_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:swe_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "name:und_x_variant":[
         "Basni Bailima"
     ],
     "name:war_x_preferred":[
-        "Bani"
+        "Basni"
     ],
     "qs:name":"Bani",
     "qs:name_adm0":"India",
@@ -75,6 +69,7 @@
     "qs:photos_sr":0,
     "qs:placetype":"Town",
     "qs:pop_sr":"7",
+    "src:geom":"unknown",
     "src:population":"geonames",
     "wd:wordcount":178,
     "wof:belongsto":[
@@ -103,8 +98,8 @@
         }
     ],
     "wof:id":890509893,
-    "wof:lastmodified":1566705377,
-    "wof:name":"Bani",
+    "wof:lastmodified":1573512984,
+    "wof:name":"Basni",
     "wof:parent_id":890507099,
     "wof:placetype":"locality",
     "wof:population":23414,

--- a/data/890/509/893/890509893.geojson
+++ b/data/890/509/893/890509893.geojson
@@ -23,14 +23,26 @@
     "name:cat_x_preferred":[
         "Basni"
     ],
+    "name:cat_x_variant":[
+        "Bani"
+    ],
     "name:ceb_x_preferred":[
         "Basni"
+    ],
+    "name:ceb_x_variant":[
+        "Bani"
     ],
     "name:ces_x_preferred":[
         "Basni"
     ],
+    "name:ces_x_variant":[
+        "Bani"
+    ],
     "name:deu_x_preferred":[
         "Basni"
+    ],
+    "name:deu_x_variant":[
+        "Bani"
     ],
     "name:eng_x_preferred":[
         "Basni"
@@ -38,29 +50,60 @@
     "name:eng_x_variant":[
         "Bani"
     ],
+    "name:fas_x_variant":[
+        "\u0628\u0627\u0646\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Basni"
+    ],
+    "name:fra_x_variant":[
+        "Bani"
     ],
     "name:ita_x_preferred":[
         "Basni"
     ],
+    "name:ita_x_variant":[
+        "Bani"
+    ],
+    "name:kat_x_variant":[
+        "\u10d1\u10d0\u10dc\u10d8"
+    ],
     "name:nld_x_preferred":[
         "Basni"
+    ],
+    "name:nld_x_variant":[
+        "Bani"
     ],
     "name:por_x_preferred":[
         "Basni"
     ],
+    "name:por_x_variant":[
+        "Bani"
+    ],
+    "name:rus_x_variant":[
+        "\u0411\u0430\u043d\u0438",
+        "\u0411\u0430\u0441\u043d\u0438"
+    ],
     "name:spa_x_preferred":[
         "Basni"
     ],
+    "name:spa_x_variant":[
+        "Bani"
+    ],
     "name:swe_x_preferred":[
         "Basni"
+    ],
+    "name:swe_x_variant":[
+        "Bani"
     ],
     "name:und_x_variant":[
         "Basni Bailima"
     ],
     "name:war_x_preferred":[
         "Basni"
+    ],
+    "name:war_x_variant":[
+        "Bani"
     ],
     "qs:name":"Bani",
     "qs:name_adm0":"India",
@@ -98,7 +141,7 @@
         }
     ],
     "wof:id":890509893,
-    "wof:lastmodified":1573512984,
+    "wof:lastmodified":1573513981,
     "wof:name":"Basni",
     "wof:parent_id":890507099,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700

- Updates `wof:name` and `name:*` properties in three localities in India.
- Stored existing names as variant names when necessary.
- No PIP work or geometry changes, can merge once approved.