### PR TITLE
Updated name translations

### DIFF
--- a/data/122/680/526/9/1226805269.geojson
+++ b/data/122/680/526/9/1226805269.geojson
@@ -30,6 +30,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Raimal Majri"
+    ],
+    "name:eng_x_variant":[
+        "Rainmal Majri"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
@@ -53,8 +59,8 @@
         }
     ],
     "wof:id":1226805269,
-    "wof:lastmodified":1566711338,
-    "wof:name":"Rainmal Majri",
+    "wof:lastmodified":1574295350,
+    "wof:name":"Raimal Majri",
     "wof:parent_id":890508851,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743

Fixes English name translations and `wof:name` values for locality in India.

Can merge once approved, no PIP work required.