### PR TITLE
Fix name translation for Nekowal

### DIFF
--- a/data/120/902/845/1/1209028451.geojson
+++ b/data/120/902/845/1/1209028451.geojson
@@ -27,10 +27,10 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
-        "Dadra and Nagar Haveli"
+        "Nekowal"
     ],
     "name:und_x_variant":[
         "Nekow\u0101l"
@@ -52,7 +52,7 @@
         }
     ],
     "wof:id":1209028451,
-    "wof:lastmodified":1566696524,
+    "wof:lastmodified":1575916306,
     "wof:name":"Nekowal",
     "wof:parent_id":85632469,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1722

This PR updates the `name:eng_x_preferred` value for the Nekowal locality record. The existing value is not correct and should not be stored as a variant name.

No PIP work required.