### PR TITLE
Standardize on unknown source

### DIFF
--- a/data/102/556/027/102556027.geojson
+++ b/data/102/556/027/102556027.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"75.6428313541,32.2508061731,75.6428313541,32.2508061731",
+    "geom:bbox":"75.642831,32.250806,75.642831,32.250806",
     "geom:latitude":32.250806,
     "geom:longitude":75.642831,
     "iso:country":"IN",
@@ -46,7 +46,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043f\u043e\u0442\u043e\u043d\u043a\u0443\u0442"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":174,
     "woe:hierarchy":{
@@ -68,7 +68,7 @@
         "wd:id":"Q7144700"
     },
     "wof:country":"IN",
-    "wof:geomhash":"ca2d3ad9d92e98cc79da01d176aeb5ae",
+    "wof:geomhash":"c5b58130cf689bf084bc4dbb082f3278",
     "wof:hierarchy":[
         {
             "campus_id":102556027,
@@ -81,7 +81,7 @@
         }
     ],
     "wof:id":102556027,
-    "wof:lastmodified":1566685268,
+    "wof:lastmodified":1589219004,
     "wof:name":"Pathankot Airport",
     "wof:parent_id":102029059,
     "wof:placetype":"campus",
@@ -93,10 +93,10 @@
     ]
 },
   "bbox": [
-    75.642831354059,
-    32.250806173066,
-    75.642831354059,
-    32.250806173066
+    75.642831,
+    32.250806,
+    75.642831,
+    32.250806
 ],
-  "geometry": {"coordinates":[75.642831354059,32.250806173066],"type":"Point"}
+  "geometry": {"coordinates":[75.642831,32.250806],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst/whosonfirst-sources/issues/112.

Swaps any "missing" values in `src:geom` properties to "unknown". I also checked values in `src:geom_alt` and `wof:geom_alt` properties, but there were no cases.

No PIP required, can merge once approved.