### PR TITLE
Update locality names

### DIFF
--- a/data/132/709/267/7/1327092677.geojson
+++ b/data/132/709/267/7/1327092677.geojson
@@ -30,127 +30,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
-    "name:afr_x_preferred":[
-        "Kakie"
+    "name:eng_x_preferred":[
+        "Khakh"
     ],
-    "name:ara_x_preferred":[
-        "\u062e\u0627\u0643\u064a"
-    ],
-    "name:bel_x_preferred":[
-        "\u0425\u0430\u043a\u0456"
-    ],
-    "name:cat_x_preferred":[
-        "Caqui"
-    ],
-    "name:ces_x_preferred":[
+    "name:eng_x_variant":[
         "Khaki"
-    ],
-    "name:cym_x_preferred":[
-        "Caci"
-    ],
-    "name:dan_x_preferred":[
-        "Khaki"
-    ],
-    "name:deu_x_preferred":[
-        "Khaki"
-    ],
-    "name:epo_x_preferred":[
-        "Kakia"
-    ],
-    "name:eus_x_preferred":[
-        "Kaki"
-    ],
-    "name:fas_x_preferred":[
-        "\u062e\u0627\u06a9\u06cc"
-    ],
-    "name:fin_x_preferred":[
-        "Khaki"
-    ],
-    "name:fra_x_preferred":[
-        "Kaki"
-    ],
-    "name:heb_x_preferred":[
-        "\u05d7\u05d0\u05e7\u05d9"
-    ],
-    "name:hun_x_preferred":[
-        "Khaki"
-    ],
-    "name:ind_x_preferred":[
-        "Khaki"
-    ],
-    "name:ita_x_preferred":[
-        "Cachi"
-    ],
-    "name:jpn_x_preferred":[
-        "\u30ab\u30fc\u30ad\u8272"
-    ],
-    "name:kor_x_preferred":[
-        "\uce74\ud0a4\uc0c9"
-    ],
-    "name:nld_x_preferred":[
-        "Kaki"
-    ],
-    "name:nno_x_preferred":[
-        "Kaki"
-    ],
-    "name:nor_x_preferred":[
-        "Khaki"
-    ],
-    "name:pnb_x_preferred":[
-        "\u062e\u0627\u06a9\u06cc"
-    ],
-    "name:pol_x_preferred":[
-        "Khaki"
-    ],
-    "name:por_x_preferred":[
-        "Caqui"
-    ],
-    "name:rus_x_preferred":[
-        "\u0425\u0430\u043a\u0438"
-    ],
-    "name:slk_x_preferred":[
-        "Kaki"
-    ],
-    "name:spa_x_preferred":[
-        "Caqui"
-    ],
-    "name:srp_x_preferred":[
-        "\u041a\u0430\u043a\u0438 \u0431\u043e\u0458\u0430"
-    ],
-    "name:swe_x_preferred":[
-        "Khaki"
-    ],
-    "name:tat_x_preferred":[
-        "\u0425\u0430\u043a\u0438"
-    ],
-    "name:tha_x_preferred":[
-        "\u0e2a\u0e35\u0e01\u0e32\u0e01\u0e35"
-    ],
-    "name:ukr_x_preferred":[
-        "\u0425\u0430\u043a\u0456"
-    ],
-    "name:urd_x_preferred":[
-        "\u062e\u0627\u06a9\u06cc"
-    ],
-    "name:vie_x_preferred":[
-        "Kaki"
-    ],
-    "name:zho_x_preferred":[
-        "\u5361\u5176\u8272"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
         85632469,
-        85672195,
-        890508953
+        890508953,
+        85672195
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":10702683
     },
     "wof:country":"IN",
-    "wof:geomhash":"c9e76cd7e4840d9459a6b1427f5bc786",
+    "wof:geomhash":"95969895232352b17905a43130072a25",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,8 +59,8 @@
         }
     ],
     "wof:id":1327092677,
-    "wof:lastmodified":1566681201,
-    "wof:name":"Khaki",
+    "wof:lastmodified":1601943322,
+    "wof:name":"Khakh",
     "wof:parent_id":890508953,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",
@@ -171,10 +69,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    75.63571999999998,
+    75.63572,
     31.6455,
-    75.63571999999998,
+    75.63572,
     31.6455
 ],
-  "geometry": {"coordinates":[75.63571999999998,31.6455],"type":"Point"}
+  "geometry": {"coordinates":[75.63572000000001,31.6455],"type":"Point"}
 }


### PR DESCRIPTION
Updates locality name from "Khaki" to "Khakh", stores English variant, and removes wiki-sourced translations for "Khaki".

No PIP work needed, just property edits.