### PR TITLE
Correct IN localities

### DIFF
--- a/data/131/058/523/9/1310585239.geojson
+++ b/data/131/058/523/9/1310585239.geojson
@@ -35,15 +35,15 @@
     "wof:belongsto":[
         102191569,
         85632469,
-        85672249,
-        890509009
+        890509009,
+        85672249
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":11429280
     },
     "wof:country":"IN",
-    "wof:geomhash":"4c445960997d692f27f05c0d4008d025",
+    "wof:geomhash":"979af312d1a7bc3a1655a7afb5f1fc16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,20 +54,22 @@
         }
     ],
     "wof:id":1310585239,
-    "wof:lastmodified":1566702379,
+    "wof:lastmodified":1617990658,
     "wof:name":"Bhupatbhai Matholiya",
     "wof:parent_id":890509009,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",
-    "wof:superseded_by":[1729972709],
+    "wof:superseded_by":[
+        1729972709
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    71.76895999999998,
+    71.76896,
     22.1076,
-    71.76895999999998,
+    71.76896,
     22.1076
 ],
-  "geometry": {"coordinates":[71.76895999999998,22.1076],"type":"Point"}
+  "geometry": {"coordinates":[71.76896000000001,22.1076],"type":"Point"}
 }

--- a/data/131/058/523/9/1310585239.geojson
+++ b/data/131/058/523/9/1310585239.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-04-09",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -28,7 +29,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -58,7 +59,7 @@
     "wof:parent_id":890509009,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-in",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[1729972709],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/172/997/270/9/1729972709.geojson
+++ b/data/172/997/270/9/1729972709.geojson
@@ -43,7 +43,7 @@
         }
     ],
     "wof:id":1729972709,
-    "wof:lastmodified":1617987292,
+    "wof:lastmodified":1617990665,
     "wof:name":"Lathidad",
     "wof:parent_id":890509009,
     "wof:placetype":"locality",

--- a/data/172/997/270/9/1729972709.geojson
+++ b/data/172/997/270/9/1729972709.geojson
@@ -1,0 +1,62 @@
+{
+  "id": 1729972709,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"71.76896,22.1076,71.76896,22.1076",
+    "geom:latitude":22.1076,
+    "geom:longitude":71.76896,
+    "iso:country":"IN",
+    "lbl:bbox":"71.74896,22.0876,71.78896,22.1276",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Lathidad"
+    ],
+    "name:guj_x_preferred":[
+        "\u0ab2\u0abe\u0aa0\u0ac0\u0aa6\u0aa1"
+    ],
+    "src:geom":"whosonfirst",
+    "wof:belongsto":[
+        102191569,
+        85632469,
+        890509009,
+        85672249
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{},
+    "wof:country":"IN",
+    "wof:geomhash":"979af312d1a7bc3a1655a7afb5f1fc16",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191569,
+            "country_id":85632469,
+            "county_id":890509009,
+            "locality_id":1729972709,
+            "region_id":85672249
+        }
+    ],
+    "wof:id":1729972709,
+    "wof:lastmodified":1617987292,
+    "wof:name":"Lathidad",
+    "wof:parent_id":890509009,
+    "wof:placetype":"locality",
+    "wof:repo":"whosonfirst-data-admin-in",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    71.76896,
+    22.1076,
+    71.76896,
+    22.1076
+],
+  "geometry": {"coordinates":[71.76896000000001,22.1076],"type":"Point"}
+}


### PR DESCRIPTION
This place doesn't actually exist: https://spelunker.whosonfirst.org/id/1310585239/

Instead, the locality in this area (22.1076,71.76896) should be represented through a record for "Lathidad". This PR deprecates the existing record above, and adds a new record for Lathidad.

No PIP work needed, can merge as-is.