### PR TITLE
Update centroid, names, hierarchy, parent_id of Darjeeling

### DIFF
--- a/data/102/030/441/102030441.geojson
+++ b/data/102/030/441/102030441.geojson
@@ -260,7 +260,7 @@
     "qs:source":"Dquattroshapes",
     "qs:type":"Town",
     "reversegeo:latitude":27.040622,
-    "reversegeo:longitude":882657292.0,
+    "reversegeo:longitude":88.265729,
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes_pg",
@@ -304,7 +304,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1666635647,
+    "wof:lastmodified":1666639422,
     "wof:name":"Darjeeling",
     "wof:parent_id":890511213,
     "wof:placetype":"locality",

--- a/data/102/030/441/102030441.geojson
+++ b/data/102/030/441/102030441.geojson
@@ -12,7 +12,7 @@
     "gn:population":123797,
     "iso:country":"IN",
     "lbl:latitude":27.040622,
-    "lbl:longitude":882657292.0,
+    "lbl:longitude":88.265729,
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":9.0,
     "mps:latitude":27.042646,
@@ -75,7 +75,8 @@
     "name:eng_x_variant":[
         "DAI",
         "Darjiling",
-        "Rdorje gling"
+        "Rdorje gling",
+        "D\u0101rjiling"
     ],
     "name:epo_x_preferred":[
         "Dar\u011diling"
@@ -267,7 +268,12 @@
     ],
     "src:lbl_centroid":"whosonfirst",
     "src:population":"geonames",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191569,
+        85632469,
+        890511213,
+        85672219
+    ],
     "wof:breaches":[],
     "wof:concordances":{
         "dbp:id":"Darjeeling",
@@ -287,19 +293,20 @@
     "wof:geomhash":"f50796e8df74099bf427fd57be27ac97",
     "wof:hierarchy":[
         {
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191569,
+            "country_id":85632469,
+            "county_id":890511213,
             "locality_id":102030441,
-            "region_id":-1
+            "region_id":85672219
         }
     ],
     "wof:id":102030441,
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1658780731,
-    "wof:name":"D\u0101rjiling",
-    "wof:parent_id":-1,
+    "wof:lastmodified":1666635647,
+    "wof:name":"Darjeeling",
+    "wof:parent_id":890511213,
     "wof:placetype":"locality",
     "wof:population":123797,
     "wof:population_rank":9,


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/2012

This PR fixes some issues in the locality record for Darjeeling:

- Updates the lbl centroid
- Updates the English and `wof:name` properties
- Updates the hierarchy and parent_id properties

No PIP work needed.