### PR TITLE
Add new campus, supersede locality record

### DIFF
--- a/data/191/371/982/5/1913719825.geojson
+++ b/data/191/371/982/5/1913719825.geojson
@@ -1,10 +1,8 @@
 {
-  "id": 890500991,
+  "id": 1913719825,
   "type": "Feature",
   "properties": {
-    "date:cessation_lower": "2024-04-22",
-    "date:cessation_upper": "2024-04-22",
-    "edtf:cessation": "2024-04-22",
+    "edtf:cessation": "",
     "edtf:inception": "",
     "geom:area": 0,
     "geom:area_square_m": 0,
@@ -18,7 +16,7 @@
     "lbl:max_zoom": 17,
     "lbl:min_zoom": 12.5,
     "mz:hierarchy_label": 1,
-    "mz:is_current": 0,
+    "mz:is_current": 1,
     "mz:is_funky": 1,
     "mz:min_zoom": 11,
     "qs:name": "SIBM Bangalore",
@@ -31,7 +29,8 @@
       102191569,
       85632469,
       85672165,
-      890511315
+      890511315,
+      102030819
     ],
     "wof:breaches": [],
     "wof:concordances": {
@@ -44,25 +43,26 @@
     "wof:geomhash": "707e649dec588de6a1617d8bc08f4439",
     "wof:hierarchy": [
       {
+        "campus_id": 1913719825,
         "continent_id": 102191569,
         "country_id": 85632469,
         "county_id": 890511315,
-        "locality_id": 890500991,
+        "locality_id": 102030819,
         "region_id": 85672165
       }
     ],
-    "wof:id": 890500991,
-    "wof:lastmodified": 1713838708,
+    "wof:id": 1913719825,
+    "wof:lastmodified": 1713838726,
     "wof:name": "SIBM Bangalore",
-    "wof:parent_id": 890511315,
-    "wof:placetype": "locality",
+    "wof:parent_id": 102030819,
+    "wof:placetype": "campus",
     "wof:population": 450,
     "wof:population_rank": 2,
     "wof:repo": "whosonfirst-data-admin-in",
-    "wof:superseded_by": [
-      1913719825
+    "wof:superseded_by": [],
+    "wof:supersedes": [
+      890500991
     ],
-    "wof:supersedes": [],
     "wof:tags": []
   },
   "bbox": [


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/2189

This PR supersedes an existing locality record in Bangalore to a new campus record. The hierarchy, placetype, superseding, and parent_ids should all be set in the new record. No PIP work required, since this record has a Point geometry.

**Number of records updated**: 1
**Number of new records**: 1